### PR TITLE
Merge pull request #125 from aws-lumberyard-dev/TexturePresets-ATOM-14765

### DIFF
--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/BuilderSettings/BuilderSettingManager.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/BuilderSettings/BuilderSettingManager.cpp
@@ -524,6 +524,10 @@ namespace ImageProcessingAtom
             {
                 return outPreset;
             }
+            else
+            {
+                AZ_Warning("Image Processing", false, "Image dimensions are not compatible with preset '%s'. The default preset will be used.", presetInfo->m_name.c_str());
+            }
         }
 
         //uncompressed one which could be used for almost everything

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/ImageBuilderComponent.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/ImageBuilderComponent.cpp
@@ -79,7 +79,7 @@ namespace ImageProcessingAtom
         builderDescriptor.m_busId = azrtti_typeid<ImageBuilderWorker>();
         builderDescriptor.m_createJobFunction = AZStd::bind(&ImageBuilderWorker::CreateJobs, &m_imageBuilder, AZStd::placeholders::_1, AZStd::placeholders::_2);
         builderDescriptor.m_processJobFunction = AZStd::bind(&ImageBuilderWorker::ProcessJob, &m_imageBuilder, AZStd::placeholders::_1, AZStd::placeholders::_2);
-        builderDescriptor.m_version = 19;   // [ATOM-14459]
+        builderDescriptor.m_version = 22;   // [ATOM-14765]
         builderDescriptor.m_analysisFingerprint = ImageProcessingAtom::BuilderSettingManager::Instance()->GetAnalysisFingerprint();
         m_imageBuilder.BusConnect(builderDescriptor.m_busId);
         AssetBuilderSDK::AssetBuilderBus::Broadcast(&AssetBuilderSDK::AssetBuilderBusTraits::RegisterBuilderInformation, builderDescriptor);

--- a/Gems/Atom/Asset/ImageProcessingAtom/Config/Albedo.preset
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Config/Albedo.preset
@@ -11,6 +11,7 @@
                 "_basecolor",
                 "_diff",
                 "_color",
+                "_col",
                 "_albedo",
                 "_alb",
                 "_bc",
@@ -31,6 +32,7 @@
                 "FileMasks": [
                     "_diff",
                     "_color",
+                    "_col",
                     "_albedo",
                     "_alb",
                     "_basecolor",
@@ -51,6 +53,7 @@
                 "FileMasks": [
                     "_diff",
                     "_color",
+                    "_col",
                     "_albedo",
                     "_alb",
                     "_basecolor",
@@ -71,6 +74,7 @@
                 "FileMasks": [
                     "_diff",
                     "_color",
+                    "_col",
                     "_albedo",
                     "_alb",
                     "_basecolor",
@@ -91,6 +95,7 @@
                 "FileMasks": [
                     "_diff",
                     "_color",
+                    "_col",
                     "_albedo",
                     "_alb",
                     "_basecolor",

--- a/Gems/Atom/Asset/ImageProcessingAtom/Config/AmbientOcclusion.preset
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Config/AmbientOcclusion.preset
@@ -9,7 +9,10 @@
             "SourceColor": "Linear",
             "DestColor": "Linear",
             "FileMasks": [
-                "_ao"
+                "_ao",
+                "_ambocc",
+                "_amb",
+                "_ambientocclusion"
             ],
             "PixelFormat": "BC4"
         },
@@ -33,7 +36,10 @@
                 "SourceColor": "Linear",
                 "DestColor": "Linear",
                 "FileMasks": [
-                    "_ao"
+                    "_ao",
+                    "_ambocc",
+                    "_amb",
+                    "_ambientocclusion"
                 ],
                 "PixelFormat": "EAC_R11"
             },
@@ -43,7 +49,10 @@
                 "SourceColor": "Linear",
                 "DestColor": "Linear",
                 "FileMasks": [
-                    "_ao"
+                    "_ao",
+                    "_ambocc",
+                    "_amb",
+                    "_ambientocclusion"
                 ],
                 "PixelFormat": "BC4"
             },
@@ -53,7 +62,10 @@
                 "SourceColor": "Linear",
                 "DestColor": "Linear",
                 "FileMasks": [
-                    "_ao"
+                    "_ao",
+                    "_ambocc",
+                    "_amb",
+                    "_ambientocclusion"
                 ],
                 "PixelFormat": "BC4"
             }

--- a/Gems/Atom/Asset/ImageProcessingAtom/Config/Displacement.preset
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Config/Displacement.preset
@@ -9,12 +9,20 @@
             "SourceColor": "Linear",
             "DestColor": "Linear",
             "FileMasks": [
-                "_displ"
+                "_displ",
+                "_disp",
+                "_dsp",
+                "_d",
+                "_dm",
+                "_displacement",
+                "_height",
+                "_hm",
+                "_ht",
+                "_h"
             ],
             "PixelFormat": "BC4",
             "DiscardAlpha": true,
             "IsPowerOf2": true,
-            "Swizzle": "aaa1",
             "MipMapSetting": {
                 "MipGenType": "Box"
             }
@@ -26,13 +34,21 @@
                 "SourceColor": "Linear",
                 "DestColor": "Linear",
                 "FileMasks": [
-                    "_displ"
+                    "_displ",
+                    "_disp",
+                    "_dsp",
+                    "_d",
+                    "_dm",
+                    "_displacement",
+                    "_height",
+                    "_hm",
+                    "_ht",
+                    "_h"
                 ],
                 "PixelFormat": "EAC_R11",
                 "DiscardAlpha": true,
                 "IsPowerOf2": true,
                 "SizeReduceLevel": 3,
-                "Swizzle": "aaa1",
                 "MipMapSetting": {
                     "MipGenType": "Box"
                 }
@@ -57,7 +73,6 @@
                 "PixelFormat": "EAC_R11",
                 "DiscardAlpha": true,
                 "IsPowerOf2": true,
-                "Swizzle": "aaa1",
                 "MipMapSetting": {
                     "MipGenType": "Box"
                 }
@@ -68,12 +83,20 @@
                 "SourceColor": "Linear",
                 "DestColor": "Linear",
                 "FileMasks": [
-                    "_displ"
+                    "_displ",
+                    "_disp",
+                    "_dsp",
+                    "_d",
+                    "_dm",
+                    "_displacement",
+                    "_height",
+                    "_hm",
+                    "_ht",
+                    "_h"
                 ],
                 "PixelFormat": "BC4",
                 "DiscardAlpha": true,
                 "IsPowerOf2": true,
-                "Swizzle": "aaa1",
                 "MipMapSetting": {
                     "MipGenType": "Box"
                 }
@@ -84,12 +107,20 @@
                 "SourceColor": "Linear",
                 "DestColor": "Linear",
                 "FileMasks": [
-                    "_displ"
+                    "_displ",
+                    "_disp",
+                    "_dsp",
+                    "_d",
+                    "_dm",
+                    "_displacement",
+                    "_height",
+                    "_hm",
+                    "_ht",
+                    "_h"
                 ],
                 "PixelFormat": "BC4",
                 "DiscardAlpha": true,
                 "IsPowerOf2": true,
-                "Swizzle": "aaa1",
                 "MipMapSetting": {
                     "MipGenType": "Box"
                 }

--- a/Gems/Atom/Asset/ImageProcessingAtom/Config/Emissive.preset
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Config/Emissive.preset
@@ -8,7 +8,11 @@
             "Name": "Emissive",
             "RGB_Weight": "CIEXYZ",
             "FileMasks": [
-                "_emissive"
+                    "_emissive",
+                    "_e",
+                    "_glow",
+                    "_em",
+                    "_emit"
             ],
             "PixelFormat": "BC7",
             "DiscardAlpha": true
@@ -33,7 +37,11 @@
                 "Name": "Emissive",
                 "RGB_Weight": "CIEXYZ",
                 "FileMasks": [
-                    "_emissive"
+                    "_emissive",
+                    "_e",
+                    "_glow",
+                    "_em",
+                    "_emit"
                 ],
                 "PixelFormat": "ASTC_6x6",
                 "DiscardAlpha": true
@@ -43,7 +51,11 @@
                 "Name": "Emissive",
                 "RGB_Weight": "CIEXYZ",
                 "FileMasks": [
-                    "_emissive"
+                    "_emissive",
+                    "_e",
+                    "_glow",
+                    "_em",
+                    "_emit"
                 ],
                 "PixelFormat": "BC7",
                 "DiscardAlpha": true
@@ -53,7 +65,11 @@
                 "Name": "Emissive",
                 "RGB_Weight": "CIEXYZ",
                 "FileMasks": [
-                    "_emissive"
+                    "_emissive",
+                    "_e",
+                    "_glow",
+                    "_em",
+                    "_emit"
                 ],
                 "PixelFormat": "BC7",
                 "DiscardAlpha": true

--- a/Gems/Atom/Asset/ImageProcessingAtom/Config/IBLSkybox.preset
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Config/IBLSkybox.preset
@@ -27,7 +27,7 @@
         },
         "PlatformsPresets": {
             "es3": {
-            	"UUID": "{E6441EAC-9843-484B-8EFC-C03B2935B48D}",
+                "UUID": "{E6441EAC-9843-484B-8EFC-C03B2935B48D}",
                 "Name": "IBLSkybox",
                 "FileMasks": [
                     "_iblskyboxcm"
@@ -61,7 +61,7 @@
                 "MinTextureSize": 256,
                 "IsPowerOf2": true,
                 "CubemapSettings": {
-                	"RequiresConvolve": false,
+                    "RequiresConvolve": false,
                     "GenerateIBLSpecular": true,
                     "IBLSpecularPreset": "{908DA68C-97FB-4C4A-97BC-5A55F30F14FA}",
                     "GenerateIBLDiffuse": true,
@@ -69,7 +69,7 @@
                 }
             },
             "osx_gl": {
-            	"UUID": "{E6441EAC-9843-484B-8EFC-C03B2935B48D}",
+                "UUID": "{E6441EAC-9843-484B-8EFC-C03B2935B48D}",
                 "Name": "IBLSkybox",
                 "FileMasks": [
                     "_iblskyboxcm"

--- a/Gems/Atom/Asset/ImageProcessingAtom/Config/LayerMask.preset
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Config/LayerMask.preset
@@ -9,7 +9,8 @@
             "SourceColor": "Linear",
             "DestColor": "Linear",
             "FileMasks": [
-                "_layers"
+                "_layers",
+                "_rgbmask"
             ],
             "PixelFormat": "R8G8B8X8"
         },
@@ -20,7 +21,8 @@
                 "SourceColor": "Linear",
                 "DestColor": "Linear",
                 "FileMasks": [
-                    "_layers"
+                    "_layers",
+                    "_rgbmask"
                 ],
                 "PixelFormat": "R8G8B8X8"
             },
@@ -30,7 +32,8 @@
                 "SourceColor": "Linear",
                 "DestColor": "Linear",
                 "FileMasks": [
-                    "_layers"
+                    "_layers",
+                    "_rgbmask"
                 ],
                 "PixelFormat": "R8G8B8X8"
             },
@@ -40,7 +43,8 @@
                 "SourceColor": "Linear",
                 "DestColor": "Linear",
                 "FileMasks": [
-                    "_layers"
+                    "_layers",
+                    "_rgbmask"
                 ],
                 "PixelFormat": "R8G8B8X8"
             },
@@ -50,7 +54,8 @@
                 "SourceColor": "Linear",
                 "DestColor": "Linear",
                 "FileMasks": [
-                    "_layers"
+                    "_layers",
+                    "_rgbmask"
                 ],
                 "PixelFormat": "R8G8B8X8"
             }

--- a/Gems/Atom/Asset/ImageProcessingAtom/Config/NormalsWithSmoothness.preset
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Config/NormalsWithSmoothness.preset
@@ -9,7 +9,11 @@
             "SourceColor": "Linear",
             "DestColor": "Linear",
             "FileMasks": [
-                "_ddna"
+                "_ddna",
+                "_normala",
+                "_nrma",
+                "_nma",
+                "_na"
             ],
             "PixelFormat": "BC5s",
             "PixelFormatAlpha": "BC4",
@@ -48,7 +52,11 @@
                 "SourceColor": "Linear",
                 "DestColor": "Linear",
                 "FileMasks": [
-                    "_ddna"
+                    "_ddna",
+                    "_normala",
+                    "_nrma",
+                    "_nma",
+                    "_na"
                 ],
                 "PixelFormat": "ASTC_4x4",
                 "PixelFormatAlpha": "ASTC_4x4",
@@ -65,7 +73,11 @@
                 "SourceColor": "Linear",
                 "DestColor": "Linear",
                 "FileMasks": [
-                    "_ddna"
+                    "_ddna",
+                    "_normala",
+                    "_nrma",
+                    "_nma",
+                    "_na"
                 ],
                 "PixelFormat": "BC5s",
                 "PixelFormatAlpha": "BC4",
@@ -82,7 +94,11 @@
                 "SourceColor": "Linear",
                 "DestColor": "Linear",
                 "FileMasks": [
-                    "_ddna"
+                    "_ddna",
+                    "_normala",
+                    "_nrma",
+                    "_nma",
+                    "_na"
                 ],
                 "PixelFormat": "BC5s",
                 "PixelFormatAlpha": "BC4",

--- a/Gems/Atom/Asset/ImageProcessingAtom/Config/Opacity.preset
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Config/Opacity.preset
@@ -11,7 +11,14 @@
             "FileMasks": [
                 "_sss",
                 "_trans",
-                "_opac"
+                "_opac",
+                "_opacity",
+                "_o",
+                "_opac",
+                "_op",
+                "_mask",
+                "_msk",
+                "_blend"
             ],
             "PixelFormat": "BC4",
             "IsPowerOf2": true,
@@ -28,7 +35,14 @@
                 "FileMasks": [
                     "_sss",
                     "_trans",
-                    "_opac"
+                    "_opac",
+                    "_opacity",
+                    "_o",
+                    "_opac",
+                    "_op",
+                    "_mask",
+                    "_msk",
+                    "_blend"
                 ],
                 "PixelFormat": "EAC_R11",
                 "IsPowerOf2": true,
@@ -67,7 +81,14 @@
                 "FileMasks": [
                     "_sss",
                     "_trans",
-                    "_opac"
+                    "_opac",
+                    "_opacity",
+                    "_o",
+                    "_opac",
+                    "_op",
+                    "_mask",
+                    "_msk",
+                    "_blend"
                 ],
                 "PixelFormat": "BC4",
                 "IsPowerOf2": true,
@@ -83,7 +104,14 @@
                 "FileMasks": [
                     "_sss",
                     "_trans",
-                    "_opac"
+                    "_opac",
+                    "_opacity",
+                    "_o",
+                    "_opac",
+                    "_op",
+                    "_mask",
+                    "_msk",
+                    "_blend"
                 ],
                 "PixelFormat": "BC4",
                 "IsPowerOf2": true,

--- a/Gems/Atom/Asset/ImageProcessingAtom/Config/Reflectance.preset
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Config/Reflectance.preset
@@ -24,7 +24,8 @@
                 "_mt",
                 "_metalness",
                 "_metallic",
-                "_roughness"
+                "_roughness",
+                "_rough"
             ],
             "PixelFormat": "BC1",
             "IsPowerOf2": true,
@@ -53,7 +54,8 @@
                     "_mt",
                     "_metalness",
                     "_metallic",
-                    "_roughness"
+                    "_roughness",
+                    "_rough"
                 ],
                 "PixelFormat": "ETC2",
                 "IsPowerOf2": true,
@@ -81,7 +83,8 @@
                     "_mt",
                     "_metalness",
                     "_metallic",
-                    "_roughness"
+                    "_roughness",
+                    "_rough"
                 ],
                 "PixelFormat": "ASTC_6x6",
                 "IsPowerOf2": true,
@@ -109,7 +112,8 @@
                     "_mt",
                     "_metalness",
                     "_metallic",
-                    "_roughness"
+                    "_roughness",
+                    "_rough"
                 ],
                 "PixelFormat": "BC1",
                 "IsPowerOf2": true,
@@ -137,7 +141,8 @@
                     "_mt",
                     "_metalness",
                     "_metallic",
-                    "_roughness"
+                    "_roughness",
+                    "_rough"
                 ],
                 "PixelFormat": "BC1",
                 "IsPowerOf2": true,

--- a/Gems/Atom/TestData/TestData/Materials/StandardMultilayerPbrTestCases/001_ManyFeatures.material
+++ b/Gems/Atom/TestData/TestData/Materials/StandardMultilayerPbrTestCases/001_ManyFeatures.material
@@ -11,7 +11,7 @@
                 0.12039368599653244,
                 1.0
             ],
-            "textureMap": "TestData/Textures/cc0/bark1col.jpg"
+            "textureMap": "TestData/Textures/cc0/bark1_col.jpg"
         },
         "layer1_emissive": {
             "color": [
@@ -34,11 +34,11 @@
         "layer1_parallax": {
             "enable": true,
             "factor": 0.02500000037252903,
-            "textureMap": "TestData/Textures/cc0/bark1disp2.jpg"
+            "textureMap": "TestData/Textures/cc0/bark1_disp.jpg"
         },
         "layer1_roughness": {
             "lowerBound": 0.010100999847054482,
-            "textureMap": "TestData/Textures/cc0/bark1roughness.jpg"
+            "textureMap": "TestData/Textures/cc0/bark1_roughness.jpg"
         },
         "layer1_specularF0": {
             "factor": 0.5099999904632568,

--- a/Gems/Atom/TestData/TestData/Materials/StandardMultilayerPbrTestCases/002_ParallaxPdo.material
+++ b/Gems/Atom/TestData/TestData/Materials/StandardMultilayerPbrTestCases/002_ParallaxPdo.material
@@ -5,18 +5,18 @@
     "propertyLayoutVersion": 3,
     "properties": {
         "layer1_baseColor": {
-            "textureMap": "TestData/Textures/cc0/bark1col.jpg"
+            "textureMap": "TestData/Textures/cc0/bark1_col.jpg"
         },
         "layer1_normal": {
-            "textureMap": "TestData/Textures/cc0/bark1norm.jpg"
+            "textureMap": "TestData/Textures/cc0/bark1_norm.jpg"
         },
         "layer1_parallax": {
             "enable": true,
             "factor": 0.03999999910593033,
-            "textureMap": "TestData/Textures/cc0/bark1disp2.jpg"
+            "textureMap": "TestData/Textures/cc0/bark1_disp.jpg"
         },
         "layer1_roughness": {
-            "textureMap": "TestData/Textures/cc0/bark1roughness.jpg"
+            "textureMap": "TestData/Textures/cc0/bark1_roughness.jpg"
         },
         "layer2_baseColor": {
             "textureMap": "TestData/Textures/cc0/Rock030_2K_Color.jpg"

--- a/Gems/Atom/TestData/TestData/Textures/cc0/bark1_col.jpg
+++ b/Gems/Atom/TestData/TestData/Textures/cc0/bark1_col.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bd44119610135ca5674de7144647df6580d7ac3e03576e9a8e87e741548e7364
+size 2105853

--- a/Gems/Atom/TestData/TestData/Textures/cc0/bark1_disp.jpg
+++ b/Gems/Atom/TestData/TestData/Textures/cc0/bark1_disp.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4dbb74aac2450d6457bb02d36bd3d74e671c2dc7e938e090331151ecc52d545b
+size 845683

--- a/Gems/Atom/TestData/TestData/Textures/cc0/bark1_norm.jpg
+++ b/Gems/Atom/TestData/TestData/Textures/cc0/bark1_norm.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e69a3844c3a595245619a9dda4ed8981476a516ad3648a8b4dfb8151a68b0db5
+size 4439966

--- a/Gems/Atom/TestData/TestData/Textures/cc0/bark1_roughness.jpg
+++ b/Gems/Atom/TestData/TestData/Textures/cc0/bark1_roughness.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a8caa5961599624a6414d7277c389dd85b175b9587989b815ffd90aff8f62b6c
+size 1747230

--- a/Gems/Atom/TestData/TestData/Textures/cc0/bark1col.jpg
+++ b/Gems/Atom/TestData/TestData/Textures/cc0/bark1col.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:24f5c234f11a1b29de9000b5a7ba74262f1bc5ebd2227ca1e85a12fa0e8b5237
-size 8273450

--- a/Gems/Atom/TestData/TestData/Textures/cc0/bark1disp.jpg
+++ b/Gems/Atom/TestData/TestData/Textures/cc0/bark1disp.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0112ac235da74c60105b0e1a2da49c1e4ab7b89a60960a60cec54ad65db0b4b6
-size 4585685

--- a/Gems/Atom/TestData/TestData/Textures/cc0/bark1disp2.jpg
+++ b/Gems/Atom/TestData/TestData/Textures/cc0/bark1disp2.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6a202449e5d787e76d959b6bee7a4b60b3821441ac918944c21358742ed1c546
-size 878112

--- a/Gems/Atom/TestData/TestData/Textures/cc0/bark1norm.jpg
+++ b/Gems/Atom/TestData/TestData/Textures/cc0/bark1norm.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b0100b3c356d76ae1cb4c42bd4cc9c58ff359155aab6b9e3c1b205fe25956738
-size 16848020

--- a/Gems/Atom/TestData/TestData/Textures/cc0/bark1roughness.jpg
+++ b/Gems/Atom/TestData/TestData/Textures/cc0/bark1roughness.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:11badf07e6a7d0501c915f669ff1b14c8744d427d47d06e2fdca46b8f86839c9
-size 4441528


### PR DESCRIPTION
ATOM-14765 Add More Texture Preset Masks

Several image preset files had a full list of file masks for only one platform. I made sure that the same list was applied to every platform including the default preset.
Removed the "Swizzle" command from Displacement.preset. Swizzle "aaa1" is wrong since this preset expects a single channel image.
Added "_col" to Albedo.preset as an abbreviation for "_color".
Added "_rough" to Roughness.preset as it's a common abbreviation.
Added "_rgbmask" filter to LayerMask.preset to correspond to the "_mask" filter in Grayscale.preset.
Added a warning when an image can't be processed according to the assigned preset due to dimension issues. Otherwise it's difficult to figure out why it's using the ReferenceImage preset instead of what was expected.
Resized the "bark" textures to make them compatible with the image presets.
Removed the "bark1disp2.jgp" image and just applied the changes to the original bark1disp.jpg". It's just blurred a bit to remove excessive noise.
Renamed all the "bark" textures to include an underscore "_" after "bark1" to get the image pipeline to properly recognize the file masks.
Testing:

AtomSampleViewer automation.
All assets in AtomTest build.
Opened several levels in AtomTest.
Corresponds to aws-lumberyard/o3de-atom-sampleviewer#17

(cherry picked from commit c64632aeffb599f7e2398b8a7ba19775d9c13964)