### PR TITLE
Merging PR 371 from O3DE 1.0 to Apocalypse

### DIFF
--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/ActorAsset.cpp
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/ActorAsset.cpp
@@ -515,7 +515,16 @@ namespace AZ
                 skinnedMeshLod.SetIndexBufferAsset(mesh0.GetIndexBufferAssetView().GetBufferAsset());
                 skinnedMeshLod.SetStaticBufferAsset(mesh0.GetSemanticBufferAssetView(Name{ "UV" })->GetBufferAsset(), SkinnedMeshStaticVertexStreams::UV_0);
 
-                const RPI::BufferAssetView* morphBufferAssetView = mesh0.GetSemanticBufferAssetView(Name{ "MORPHTARGET_VERTEXDELTAS" });
+                const RPI::BufferAssetView* morphBufferAssetView = nullptr;
+                for (const auto& mesh : modelLodAsset->GetMeshes())
+                {
+                    morphBufferAssetView = mesh.GetSemanticBufferAssetView(Name{ "MORPHTARGET_VERTEXDELTAS" });
+                    if (morphBufferAssetView)
+                    {
+                        break;
+                    }
+                }
+
                 if (morphBufferAssetView)
                 {
                     ProcessMorphsForLod(actor, morphBufferAssetView->GetBufferAsset(), lodIndex, fullFileName, skinnedMeshLod);


### PR DESCRIPTION
Instead of assuming the first submesh will always have a reference to the morph target buffer, search the submeshes to find the first one that does.

Original PR: https://github.com/aws-lumberyard/o3de/pull/371