### PR TITLE
Merge PR 530 from O3DE/1.0 to Apocalypse/1.0

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/MorphTargets/MorphTargetInputBuffers.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/MorphTargets/MorphTargetInputBuffers.h
@@ -53,6 +53,7 @@ namespace AZ
             void SetBufferViewsOnShaderResourceGroup(const Data::Instance<RPI::ShaderResourceGroup>& perInstanceSRG);
         private:
             RHI::Ptr<RHI::BufferView> m_vertexDeltaBufferView;
+            Data::Instance<RPI::Buffer> m_vertexDeltaBuffer;
         };
 
         struct MorphTargetMetaData

--- a/Gems/Atom/Feature/Common/Code/Source/MorphTargets/MorphTargetInputBuffers.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/MorphTargets/MorphTargetInputBuffers.cpp
@@ -30,16 +30,18 @@ namespace AZ
     {
         MorphTargetInputBuffers::MorphTargetInputBuffers(const RPI::BufferAssetView& bufferAssetView, const AZStd::string& bufferNamePrefix)
         {            
-            auto buffer = RPI::Buffer::FindOrCreate(bufferAssetView.GetBufferAsset());
-
-            AZ::RHI::Ptr<AZ::RHI::BufferView> bufferView = RHI::Factory::Get().CreateBufferView();
+            m_vertexDeltaBuffer = RPI::Buffer::FindOrCreate(bufferAssetView.GetBufferAsset());
+            if (m_vertexDeltaBuffer)
             {
-                bufferView->SetName(Name(bufferNamePrefix + "MorphTargetVertexDeltaView"));
-                [[maybe_unused]] RHI::ResultCode resultCode = bufferView->Init(*buffer->GetRHIBuffer(), bufferAssetView.GetBufferViewDescriptor());
-                AZ_Error("MorphTargetInputBuffers", resultCode == RHI::ResultCode::Success, "Failed to initialize buffer view for morph target.");
-            }
+                AZ::RHI::Ptr<AZ::RHI::BufferView> bufferView = RHI::Factory::Get().CreateBufferView();
+                {
+                    bufferView->SetName(Name(bufferNamePrefix + "MorphTargetVertexDeltaView"));
+                    [[maybe_unused]] RHI::ResultCode resultCode = bufferView->Init(*m_vertexDeltaBuffer->GetRHIBuffer(), bufferAssetView.GetBufferViewDescriptor());
+                    AZ_Error("MorphTargetInputBuffers", resultCode == RHI::ResultCode::Success, "Failed to initialize buffer view for morph target.");
+                }
 
-            m_vertexDeltaBufferView = bufferView;
+                m_vertexDeltaBufferView = bufferView;
+            }
         }
 
         void MorphTargetInputBuffers::SetBufferViewsOnShaderResourceGroup(const Data::Instance<RPI::ShaderResourceGroup>& perInstanceSRG)


### PR DESCRIPTION
Fixed a crash by keeping a reference to the buffer instance after creating it and checking for null