### PR TITLE
Merge wrinkle map support to apocalypse1.0

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/Skin.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/Skin.azsl
@@ -96,7 +96,7 @@ struct VSOutput
     float2 m_uv[UvSetCount] : UV1;
     float2 m_detailUv : UV3;
     
-    float4 m_blendMask : UV8;
+    float4 m_wrinkleBlendFactors : UV8;
 };
 
 #include <Atom/Features/Vertex/VertexHelper.azsli>
@@ -127,11 +127,11 @@ VSOutput SkinVS(VSInput IN)
     
     if(o_blendMask_isBound)
     {
-        OUT.m_blendMask = IN.m_optional_blendMask;
+        OUT.m_wrinkleBlendFactors = IN.m_optional_blendMask;
     }
     else
     {
-        OUT.m_blendMask = float4(0,1,0,0);
+        OUT.m_wrinkleBlendFactors = float4(0,0,0,0);
     }
 
     VertexHelper(IN, OUT, worldPosition, false);
@@ -209,7 +209,22 @@ PbrLightingOutput SkinPS_Common(VSOutput IN)
     
     float2 normalUv = IN.m_uv[MaterialSrg::m_normalMapUvIndex];
     float detailLayerNormalFactor = MaterialSrg::m_detail_normal_factor * detailLayerBlendFactor;
-    
+
+    // ------- Wrinkle Map Setup -------
+
+    // Combine the optional per-morph target wrinkle masks
+    float4 wrinkleBlendFactors = float4(0.0, 0.0, 0.0, 0.0);
+    for(uint wrinkleMaskIndex = 0; wrinkleMaskIndex < ObjectSrg::m_wrinkle_mask_count; ++wrinkleMaskIndex)
+    {
+        wrinkleBlendFactors += ObjectSrg::m_wrinkle_masks[wrinkleMaskIndex].Sample(MaterialSrg::m_sampler, normalUv) * ObjectSrg::GetWrinkleMaskWeight(wrinkleMaskIndex);
+    }
+
+    // If texture based morph target driven masks are being used, use those values instead of the per-vertex colors
+    if(ObjectSrg::m_wrinkle_mask_count)
+    {
+        IN.m_wrinkleBlendFactors = saturate(wrinkleBlendFactors);
+    }
+
     // Since the wrinkle normal maps should all be in the same tangent space as the main normal map, we should be able to blend the raw normal map
     // texture values before doing all the tangent space transforms, so we only have to do the transforms once, for better performance.
     
@@ -218,12 +233,12 @@ PbrLightingOutput SkinPS_Common(VSOutput IN)
     {
         normalMapSample = SampleNormalXY(MaterialSrg::m_normalMap, MaterialSrg::m_sampler, normalUv, MaterialSrg::m_flipNormalX, MaterialSrg::m_flipNormalY);
     }
-    if(o_wrinkleLayers_enabled && o_blendMask_isBound && o_wrinkleLayers_normal_enabled)
+    if(o_wrinkleLayers_enabled && o_wrinkleLayers_normal_enabled)
     {
-        normalMapSample = ApplyNormalWrinkleMap(o_wrinkleLayers_normal_useTexture1, normalMapSample, MaterialSrg::m_wrinkle_normal_texture1, MaterialSrg::m_sampler, normalUv, MaterialSrg::m_flipNormalX, MaterialSrg::m_flipNormalY, IN.m_blendMask.r);
-        normalMapSample = ApplyNormalWrinkleMap(o_wrinkleLayers_normal_useTexture2, normalMapSample, MaterialSrg::m_wrinkle_normal_texture2, MaterialSrg::m_sampler, normalUv, MaterialSrg::m_flipNormalX, MaterialSrg::m_flipNormalY, IN.m_blendMask.g);
-        normalMapSample = ApplyNormalWrinkleMap(o_wrinkleLayers_normal_useTexture3, normalMapSample, MaterialSrg::m_wrinkle_normal_texture3, MaterialSrg::m_sampler, normalUv, MaterialSrg::m_flipNormalX, MaterialSrg::m_flipNormalY, IN.m_blendMask.b);
-        normalMapSample = ApplyNormalWrinkleMap(o_wrinkleLayers_normal_useTexture4, normalMapSample, MaterialSrg::m_wrinkle_normal_texture4, MaterialSrg::m_sampler, normalUv, MaterialSrg::m_flipNormalX, MaterialSrg::m_flipNormalY, IN.m_blendMask.a);
+        normalMapSample = ApplyNormalWrinkleMap(o_wrinkleLayers_normal_useTexture1, normalMapSample, MaterialSrg::m_wrinkle_normal_texture1, MaterialSrg::m_sampler, normalUv, MaterialSrg::m_flipNormalX, MaterialSrg::m_flipNormalY, IN.m_wrinkleBlendFactors.r);
+        normalMapSample = ApplyNormalWrinkleMap(o_wrinkleLayers_normal_useTexture2, normalMapSample, MaterialSrg::m_wrinkle_normal_texture2, MaterialSrg::m_sampler, normalUv, MaterialSrg::m_flipNormalX, MaterialSrg::m_flipNormalY, IN.m_wrinkleBlendFactors.g);
+        normalMapSample = ApplyNormalWrinkleMap(o_wrinkleLayers_normal_useTexture3, normalMapSample, MaterialSrg::m_wrinkle_normal_texture3, MaterialSrg::m_sampler, normalUv, MaterialSrg::m_flipNormalX, MaterialSrg::m_flipNormalY, IN.m_wrinkleBlendFactors.b);
+        normalMapSample = ApplyNormalWrinkleMap(o_wrinkleLayers_normal_useTexture4, normalMapSample, MaterialSrg::m_wrinkle_normal_texture4, MaterialSrg::m_sampler, normalUv, MaterialSrg::m_flipNormalX, MaterialSrg::m_flipNormalY, IN.m_wrinkleBlendFactors.a);
     }
 
     if(o_detail_normal_useTexture)
@@ -250,7 +265,7 @@ PbrLightingOutput SkinPS_Common(VSOutput IN)
     float3 baseColor = GetBaseColorInput(MaterialSrg::m_baseColorMap, MaterialSrg::m_sampler, baseColorUv, MaterialSrg::m_baseColor, o_baseColor_useTexture);
     
     bool useSampledBaseColor = o_baseColor_useTexture;
-    if(o_wrinkleLayers_enabled && o_blendMask_isBound && o_wrinkleLayers_baseColor_enabled)
+    if(o_wrinkleLayers_enabled && o_wrinkleLayers_baseColor_enabled)
     {
         // If any of the wrinkle maps are applied, we will use the Base Color blend settings to apply the MaterialSrg::m_baseColor tint to the wrinkle maps,
         // even if the main base color map is not used.
@@ -267,10 +282,10 @@ PbrLightingOutput SkinPS_Common(VSOutput IN)
             baseColor = float3(1,1,1);
         }
 
-        baseColor = ApplyBaseColorWrinkleMap(o_wrinkleLayers_baseColor_useTexture1, baseColor, MaterialSrg::m_wrinkle_baseColor_texture1, MaterialSrg::m_sampler, baseColorUv, IN.m_blendMask.r);
-        baseColor = ApplyBaseColorWrinkleMap(o_wrinkleLayers_baseColor_useTexture2, baseColor, MaterialSrg::m_wrinkle_baseColor_texture2, MaterialSrg::m_sampler, baseColorUv, IN.m_blendMask.g);
-        baseColor = ApplyBaseColorWrinkleMap(o_wrinkleLayers_baseColor_useTexture3, baseColor, MaterialSrg::m_wrinkle_baseColor_texture3, MaterialSrg::m_sampler, baseColorUv, IN.m_blendMask.b);
-        baseColor = ApplyBaseColorWrinkleMap(o_wrinkleLayers_baseColor_useTexture4, baseColor, MaterialSrg::m_wrinkle_baseColor_texture4, MaterialSrg::m_sampler, baseColorUv, IN.m_blendMask.a);
+        baseColor = ApplyBaseColorWrinkleMap(o_wrinkleLayers_baseColor_useTexture1, baseColor, MaterialSrg::m_wrinkle_baseColor_texture1, MaterialSrg::m_sampler, baseColorUv, IN.m_wrinkleBlendFactors.r);
+        baseColor = ApplyBaseColorWrinkleMap(o_wrinkleLayers_baseColor_useTexture2, baseColor, MaterialSrg::m_wrinkle_baseColor_texture2, MaterialSrg::m_sampler, baseColorUv, IN.m_wrinkleBlendFactors.g);
+        baseColor = ApplyBaseColorWrinkleMap(o_wrinkleLayers_baseColor_useTexture3, baseColor, MaterialSrg::m_wrinkle_baseColor_texture3, MaterialSrg::m_sampler, baseColorUv, IN.m_wrinkleBlendFactors.b);
+        baseColor = ApplyBaseColorWrinkleMap(o_wrinkleLayers_baseColor_useTexture4, baseColor, MaterialSrg::m_wrinkle_baseColor_texture4, MaterialSrg::m_sampler, baseColorUv, IN.m_wrinkleBlendFactors.a);
     
     }
     
@@ -278,13 +293,13 @@ PbrLightingOutput SkinPS_Common(VSOutput IN)
     
     baseColor = ApplyTextureOverlay(o_detail_baseColor_useTexture, baseColor, MaterialSrg::m_detail_baseColor_texture, MaterialSrg::m_sampler, IN.m_detailUv, detailLayerBaseColorFactor);
 
-    if(o_wrinkleLayers_enabled && o_wrinkleLayers_showBlendMaskValues && o_blendMask_isBound)
+    if(o_wrinkleLayers_enabled && o_wrinkleLayers_showBlendMaskValues)
     {
         // Overlay debug colors to highlight the different blend weights coming from the vertex color stream.
-        if(o_wrinkleLayers_count > 0) { baseColor = lerp(baseColor, float3(1,0,0), IN.m_blendMask.r); }
-        if(o_wrinkleLayers_count > 1) { baseColor = lerp(baseColor, float3(0,1,0), IN.m_blendMask.g); }
-        if(o_wrinkleLayers_count > 2) { baseColor = lerp(baseColor, float3(0,0,1), IN.m_blendMask.b); }
-        if(o_wrinkleLayers_count > 3) { baseColor = lerp(baseColor, float3(1,1,1), IN.m_blendMask.a); }
+        if(o_wrinkleLayers_count > 0) { baseColor = lerp(baseColor, float3(1,0,0), IN.m_wrinkleBlendFactors.r); }
+        if(o_wrinkleLayers_count > 1) { baseColor = lerp(baseColor, float3(0,1,0), IN.m_wrinkleBlendFactors.g); }
+        if(o_wrinkleLayers_count > 2) { baseColor = lerp(baseColor, float3(0,0,1), IN.m_wrinkleBlendFactors.b); }
+        if(o_wrinkleLayers_count > 3) { baseColor = lerp(baseColor, float3(1,1,1), IN.m_wrinkleBlendFactors.a); }
     }
 
     // ------- Specular -------

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessor.h
@@ -149,6 +149,8 @@ namespace AZ
             Data::Instance<RPI::ShaderResourceGroup> GetObjectSrg(const MeshHandle& meshHandle) const override;
             void QueueObjectSrgForCompile(const MeshHandle& meshHandle) const override;
             Data::Asset<RPI::ModelAsset> GetModelAsset(const MeshHandle& meshHandle) const override;
+            Data::Instance<RPI::ShaderResourceGroup> GetObjectSrg(const MeshHandle& meshHandle) const override;
+            void QueueObjectSrgForCompile(const MeshHandle& meshHandle) const override;
             void SetMaterialAssignmentMap(const MeshHandle& meshHandle, const Data::Instance<RPI::Material>& material) override;
             void SetMaterialAssignmentMap(const MeshHandle& meshHandle, const MaterialAssignmentMap& materials) override;
             const MaterialAssignmentMap& GetMaterialAssignmentMap(const MeshHandle& meshHandle) const override;

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessor.h
@@ -146,8 +146,6 @@ namespace AZ
             MeshHandle CloneMesh(const MeshHandle& meshHandle) override;
 
             Data::Instance<RPI::Model> GetModel(const MeshHandle& meshHandle) const override;
-            Data::Instance<RPI::ShaderResourceGroup> GetObjectSrg(const MeshHandle& meshHandle) const override;
-            void QueueObjectSrgForCompile(const MeshHandle& meshHandle) const override;
             Data::Asset<RPI::ModelAsset> GetModelAsset(const MeshHandle& meshHandle) const override;
             Data::Instance<RPI::ShaderResourceGroup> GetObjectSrg(const MeshHandle& meshHandle) const override;
             void QueueObjectSrgForCompile(const MeshHandle& meshHandle) const override;

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessorInterface.h
@@ -59,14 +59,6 @@ namespace AZ
 
             //! Gets the underlying RPI::Model instance for a meshHandle. May be null if the model has not loaded.
             virtual Data::Instance<RPI::Model> GetModel(const MeshHandle& meshHandle) const = 0;
-            //! Gets the ObjectSrg for a meshHandle.
-            //! Updating the ObjectSrg should be followed by a call to QueueObjectSrgForCompile,
-            //! instead of compiling the srg directly. This way, if the srg has already been queued for compile,
-            //! it will not be queued twice in the same frame. The ObjectSrg should not be updated during
-            //! Simulate, or it will create a race between updating the data and the call to Compile
-            virtual Data::Instance<RPI::ShaderResourceGroup> GetObjectSrg(const MeshHandle& meshHandle) const = 0;
-            //! Queues the object srg for compile.
-            virtual void QueueObjectSrgForCompile(const MeshHandle& meshHandle) const = 0;
             //! Gets the underlying RPI::ModelAsset for a meshHandle.
             virtual Data::Asset<RPI::ModelAsset> GetModelAsset(const MeshHandle& meshHandle) const = 0;
             //! Gets the ObjectSrg for a meshHandle.

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessorInterface.h
@@ -69,6 +69,14 @@ namespace AZ
             virtual void QueueObjectSrgForCompile(const MeshHandle& meshHandle) const = 0;
             //! Gets the underlying RPI::ModelAsset for a meshHandle.
             virtual Data::Asset<RPI::ModelAsset> GetModelAsset(const MeshHandle& meshHandle) const = 0;
+            //! Gets the ObjectSrg for a meshHandle.
+            //! Updating the ObjectSrg should be followed by a call to QueueObjectSrgForCompile,
+            //! instead of compiling the srg directly. This way, if the srg has already been queued for compile,
+            //! it will not be queued twice in the same frame. The ObjectSrg should not be updated during
+            //! Simulate, or it will create a race between updating the data and the call to Compile
+            virtual Data::Instance<RPI::ShaderResourceGroup> GetObjectSrg(const MeshHandle& meshHandle) const = 0;
+            //! Queues the object srg for compile.
+            virtual void QueueObjectSrgForCompile(const MeshHandle& meshHandle) const = 0;
             //! Sets the MaterialAssignmentMap for a meshHandle, using just a single material for the DefaultMaterialAssignmentId.
             //! Note if there is already a material assignment map, this will replace the entire map with just a single material.
             virtual void SetMaterialAssignmentMap(const MeshHandle& meshHandle, const Data::Instance<RPI::Material>& material) = 0;

--- a/Gems/Atom/Feature/Common/Code/Mocks/MockMeshFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Mocks/MockMeshFeatureProcessor.h
@@ -25,6 +25,8 @@ namespace UnitTest
         MOCK_CONST_METHOD1(GetObjectSrg, AZStd::intrusive_ptr<AZ::RPI::ShaderResourceGroup>(const MeshHandle&));
         MOCK_CONST_METHOD1(QueueObjectSrgForCompile, void(const MeshHandle&));
         MOCK_CONST_METHOD1(GetModelAsset, AZ::Data::Asset<AZ::RPI::ModelAsset>(const MeshHandle&));
+        MOCK_CONST_METHOD1(GetObjectSrg, AZStd::intrusive_ptr<AZ::RPI::ShaderResourceGroup>(const MeshHandle&));
+        MOCK_CONST_METHOD1(QueueObjectSrgForCompile, void(const MeshHandle&));
         MOCK_CONST_METHOD1(GetMaterialAssignmentMap, const AZ::Render::MaterialAssignmentMap&(const MeshHandle&));
         MOCK_METHOD2(ConnectModelChangeEventHandler, void(const MeshHandle&, ModelChangedEvent::Handler&));
         MOCK_METHOD2(SetTransform, void(const MeshHandle&, const AZ::Transform&));

--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
@@ -220,19 +220,6 @@ namespace AZ
         {
             return meshHandle.IsValid() ? meshHandle->m_model : nullptr;
         }
-
-        Data::Instance<RPI::ShaderResourceGroup> MeshFeatureProcessor::GetObjectSrg(const MeshHandle& meshHandle) const
-        {
-            return meshHandle.IsValid() ? meshHandle->m_shaderResourceGroup : nullptr;
-        }
-
-        void MeshFeatureProcessor::QueueObjectSrgForCompile(const MeshHandle& meshHandle) const
-        {
-            if (meshHandle.IsValid())
-            {
-                meshHandle->m_objectSrgNeedsUpdate = true;
-            }
-        }
             
         Data::Asset<RPI::ModelAsset> MeshFeatureProcessor::GetModelAsset(const MeshHandle& meshHandle) const
         {

--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
@@ -244,6 +244,19 @@ namespace AZ
             return {};
         }
 
+        Data::Instance<RPI::ShaderResourceGroup> MeshFeatureProcessor::GetObjectSrg(const MeshHandle& meshHandle) const
+        {
+            return meshHandle.IsValid() ? meshHandle->m_shaderResourceGroup : nullptr;
+        }
+
+        void MeshFeatureProcessor::QueueObjectSrgForCompile(const MeshHandle& meshHandle) const
+        {
+            if (meshHandle.IsValid())
+            {
+                meshHandle->m_objectSrgNeedsUpdate = true;
+            }
+        }
+
         void MeshFeatureProcessor::SetMaterialAssignmentMap(const MeshHandle& meshHandle, const Data::Instance<RPI::Material>& material)
         {
             Render::MaterialAssignmentMap materials;

--- a/Gems/SceneProcessing/Code/Source/SceneBuilder/SceneBuilderWorker.cpp
+++ b/Gems/SceneProcessing/Code/Source/SceneBuilder/SceneBuilderWorker.cpp
@@ -98,7 +98,7 @@ namespace SceneBuilder
             descriptor.m_jobKey = "Scene compilation";
             descriptor.SetPlatformIdentifier(enabledPlatform.m_identifier.c_str());
             descriptor.m_failOnError = true;
-            descriptor.m_priority = 11; // more important than static mesh files, since these may control logic (actors and motions specifically)
+            descriptor.m_priority = 11; // these may control logic (actors and motions specifically)
             descriptor.m_additionalFingerprintInfo = GetFingerprint();
 
             AZ::SceneAPI::SceneBuilderDependencyBus::Broadcast(&AZ::SceneAPI::SceneBuilderDependencyRequests::ReportJobDependencies,
@@ -107,11 +107,17 @@ namespace SceneBuilder
             response.m_createJobOutputs.push_back(descriptor);
         }
 
-        // Adding corresponding material file as a source file dependency
+        // Adding corresponding _wrinklemask folder as a source file dependency
+        // This enables morph target assets to get references to the wrinkle masks
+        // in the MorphTargetExporter, so they can be automatically applied at runtime
         AssetBuilderSDK::SourceFileDependency sourceFileDependencyInfo;
         AZStd::string relPath = request.m_sourceFile.c_str();
-        AzFramework::StringFunc::Path::ReplaceExtension(relPath, "mtl");
+        AzFramework::StringFunc::Path::StripExtension(relPath);
+        relPath += "_wrinklemasks";
+        AzFramework::StringFunc::Path::AppendSeparator(relPath);
+        relPath += "*_wrinklemask.*";
         sourceFileDependencyInfo.m_sourceFileDependencyPath = relPath;
+        sourceFileDependencyInfo.m_sourceDependencyType = AssetBuilderSDK::SourceFileDependency::SourceFileDependencyType::Wildcards;
         response.m_sourceFileDependencyList.push_back(sourceFileDependencyInfo);
 
         response.m_result = AssetBuilderSDK::CreateJobsResultCode::Success;


### PR DESCRIPTION
Merged a change that will automatically re-process an fbx file if a wrinkle mask is added/removed
Merged the Skin.azsl shader changes which were missing
Updated the new MeshFeatureProcessor functions, which were in a different order than they are in main (this should make it easier to merge future changes)