### PR TITLE
ATOM-15597 Accessing Material Instance Panel Crashes Editor

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/MaterialFunctor.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/MaterialFunctor.cpp
@@ -334,6 +334,7 @@ namespace AZ
             if (it == m_propertyMetadata.end())
             {
                 AZ_Error("MaterialFunctor", false, "Couldn't find metadata for material property: %s.", propertyName.GetCStr());
+                return nullptr;
             }
 
             return &it->second;
@@ -345,6 +346,7 @@ namespace AZ
             if (it == m_propertyGroupMetadata.end())
             {
                 AZ_Error("MaterialFunctor", false, "Couldn't find metadata for material property group: %s.", propertyGroupName.GetCStr());
+                return nullptr;
             }
 
             return &it->second;

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentInspector.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentInspector.cpp
@@ -297,6 +297,11 @@ namespace AZ
                 for (auto& groupPair : m_groups)
                 {
                     AZ::RPI::MaterialPropertyGroupDynamicMetadata& metadata = propertyGroupDynamicMetadata[AZ::Name{groupPair.first}];
+                    
+                    for (auto& property : groupPair.second.m_properties)
+                    {
+                        AtomToolsFramework::ConvertToPropertyMetaData(propertyDynamicMetadata[property.GetId()], property.GetConfig());
+                    }
 
                     // It's significant that we check IsGroupHidden rather than IsGroupVisisble, because it follows the same rules as QWidget::isHidden().
                     // We don't care whether the widget and all its parents are visible, we only care about whether the group was hidden within the context


### PR DESCRIPTION
There were two issues fixed here. First, I broke the material inspector with my changes at 53188a12da7d3ce90de64a0d184b6a5f9df613d8 which added support for hiding entire property groups. I'm not sure how this happened because I definitely tested the MaterialComponent's material inspector. Perhaps there was a bad merge or something otherwise got clobbered after testing and before committing. Anyway, this issue was I accidentally delete the code that prepared the list of material properties for functor processing.

The second issue was the MaterialFunctor class needs to return null when metadata can't be found; it was proceeding to dereference an end iterator.

Testing:
Successfully opened the material inspector through the MaterialComponent. Was able to change property flags in the inspector and see other properties change visibility as expected.