### PR TITLE
AssImp -> FBX SDK while we work through AssImp bugs.

### DIFF
--- a/Code/Tools/SceneAPI/FbxSceneBuilder/FbxImporter.h
+++ b/Code/Tools/SceneAPI/FbxSceneBuilder/FbxImporter.h
@@ -51,7 +51,7 @@ namespace AZ
 
                 AZStd::unique_ptr<SDKScene::SceneWrapperBase> m_sceneWrapper;
                 AZStd::shared_ptr<FbxSceneSystem> m_sceneSystem;
-                bool m_useAssetImporterSDK = true;
+                bool m_useAssetImporterSDK = false;
             };
         } // namespace FbxSceneBuilder
     } // namespace SceneAPI


### PR DESCRIPTION
This switches from AssImp back to FBX SDK, while my team works on the drooping eye bug.